### PR TITLE
feat: add realtime conversation example using OpenAI API

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -66,6 +66,7 @@ from open_webui.routers import (
     images,
     ollama,
     openai,
+    realtime,
     retrieval,
     pipelines,
     tasks,
@@ -1213,6 +1214,7 @@ app.mount("/ws", socket_app)
 
 app.include_router(ollama.router, prefix="/ollama", tags=["ollama"])
 app.include_router(openai.router, prefix="/openai", tags=["openai"])
+app.include_router(realtime.router, prefix="/api/v1/realtime", tags=["realtime"])
 
 
 app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"])

--- a/backend/open_webui/routers/realtime.py
+++ b/backend/open_webui/routers/realtime.py
@@ -1,0 +1,35 @@
+import aiohttp
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from open_webui.utils.auth import get_verified_user
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/session")
+async def create_realtime_session(request: Request, user=Depends(get_verified_user)):
+    idx = 0
+    url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
+    key = request.app.state.config.OPENAI_API_KEYS[idx]
+    session = None
+    try:
+        session = aiohttp.ClientSession(trust_env=True)
+        r = await session.post(
+            f"{url}/realtime/sessions",
+            json={"model": "gpt-4o-realtime-preview", "voice": "verse"},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        data = await r.json()
+        if r.status >= 400:
+            raise HTTPException(status_code=r.status, detail=data)
+        return data
+    except Exception as e:  # pragma: no cover - network errors
+        log.exception(e)
+        raise HTTPException(status_code=500, detail="Realtime session error")
+    finally:
+        if session:
+            await session.close()

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -1,0 +1,20 @@
+# Realtime Conversation API
+
+Open WebUI now exposes a small helper endpoint for the [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime).
+It follows the [blog post announcement](https://openai.com/blog) and the official API and prompting guides.
+
+## Usage
+
+1. Start a session by requesting an ephemeral key from the backend:
+   ```bash
+   curl -H "Authorization: Bearer <token>" \
+        https://your-webui.example.com/api/v1/realtime/session
+   ```
+2. Use the returned `client_secret` with a WebRTC connection to `gpt-4o-realtime-preview`.
+3. The included Svelte page (`/realtime`) demonstrates streaming text between the user and assistant while the
+   assistant responds aloud using the new `verse` voice.
+
+## Prompting
+
+Send conversational prompts over the data channel. The API guide linked above
+contains several examples for composing real‑time instructions.

--- a/src/lib/components/realtime/RealtimeChat.svelte
+++ b/src/lib/components/realtime/RealtimeChat.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+
+    type ChatMessage = { role: 'user' | 'assistant'; text: string };
+    let messages: ChatMessage[] = [];
+
+    let pc: RTCPeerConnection;
+    let dc: RTCDataChannel;
+
+    function append(role: 'user' | 'assistant', delta: string) {
+        const last = messages[messages.length - 1];
+        if (!last || last.role !== role) {
+            messages = [...messages, { role, text: delta }];
+        } else {
+            last.text += delta;
+            messages = [...messages];
+        }
+    }
+
+    onMount(async () => {
+        const tokenRes = await fetch('/api/v1/realtime/session');
+        const token = await tokenRes.json();
+        const EPHEMERAL_KEY = token.client_secret.value;
+
+        pc = new RTCPeerConnection();
+
+        const audioEl = document.getElementById('assistant-audio') as HTMLAudioElement;
+        pc.ontrack = (e) => {
+            audioEl.srcObject = e.streams[0];
+        };
+
+        dc = pc.createDataChannel('oai-events');
+        dc.onmessage = (ev) => {
+            try {
+                const msg = JSON.parse(ev.data);
+                if (msg.type === 'response.output_text.delta') {
+                    append('assistant', msg.delta);
+                } else if (msg.type === 'input_audio_buffer.transcript.delta') {
+                    append('user', msg.delta);
+                }
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
+        const ms = await navigator.mediaDevices.getUserMedia({ audio: true });
+        ms.getTracks().forEach((t) => pc.addTrack(t, ms));
+
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+
+        const answer = await fetch('https://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview', {
+            method: 'POST',
+            body: offer.sdp ?? '',
+            headers: {
+                Authorization: `Bearer ${EPHEMERAL_KEY}`,
+                'Content-Type': 'application/sdp'
+            }
+        });
+        const answerText = await answer.text();
+        await pc.setRemoteDescription({ type: 'answer', sdp: answerText });
+    });
+</script>
+
+<div class="space-y-4">
+    <audio id="assistant-audio" autoplay class="hidden"></audio>
+    <div class="max-h-64 overflow-y-auto border rounded p-2 text-sm">
+        {#each messages as m}
+            <div class="my-1">
+                <span class="font-bold capitalize">{m.role}:</span> {m.text}
+            </div>
+        {/each}
+    </div>
+</div>

--- a/src/routes/(app)/realtime/+page.svelte
+++ b/src/routes/(app)/realtime/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+    import RealtimeChat from '$lib/components/realtime/RealtimeChat.svelte';
+</script>
+
+<RealtimeChat />


### PR DESCRIPTION
## Summary
- add backend endpoint to create OpenAI Realtime sessions using voice `verse`
- expose Svelte realtime chat page that streams user/assistant text
- document how to start realtime conversations

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config and svelte-kit/pylint missing)*
- `npm run test:frontend` *(fails: vitest not found)*
- `pytest` *(fails: missing modules such as moto and open_webui)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fa2e727c8330b4bdce4f04290745